### PR TITLE
a stricter way of relate audio file and its name and generate a list for duplicated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# test data
+test/

--- a/BARS/BARS.cs
+++ b/BARS/BARS.cs
@@ -13,7 +13,7 @@ namespace BARS
         public BARSHeader Header;
         public AMTA[] AMTA;
         public BWAV[] BWAV;
-        private string duplicatedFiles = "These files are the linked to the same content:\n\n";
+        private string duplicatedFiles = "";
         private Dictionary<uint, List<string>> bwavFileNames = new Dictionary<uint, List<string>>();
 
         public BARSAudio(FileReader reader)
@@ -81,16 +81,23 @@ namespace BARS
             return new BARSAudio(new FileReader(new MemoryStream(File.ReadAllBytes(filename)))) { Name = name};
         }
 
-        public void Export(string path, bool fileAsSubPath = false)
+        public void Export(string path, bool fileAsSubPath, out string extraInfo)
         {
+            extraInfo = "";
+
             var savePath = fileAsSubPath ? $"{path}\\{Name}\\" : $"{path}\\";
             foreach (var bwav in BWAV)
             {               
                 File.WriteAllBytes($@"{savePath}{bwav.Name}.bwav", bwav.Data);
             }
 
-            var infoPath = $@"{savePath}\\duplicated_files.txt";
-            File.WriteAllBytes(infoPath, Encoding.UTF8.GetBytes(duplicatedFiles));
+            if (duplicatedFiles != "")
+            {
+                var infoPath = $@"{savePath}\\duplicated_files.txt";
+                File.WriteAllBytes(infoPath, Encoding.UTF8.GetBytes(duplicatedFiles));
+                extraInfo = "AMTA tags more and bwav files.";
+            }
+
         }
 
         public IEnumerable<string> List => BWAV.Select(b => b.Name);

--- a/BARS/BARS.cs
+++ b/BARS/BARS.cs
@@ -95,7 +95,7 @@ namespace BARS
             {
                 var infoPath = $@"{savePath}\\duplicated_files.txt";
                 File.WriteAllBytes(infoPath, Encoding.UTF8.GetBytes(duplicatedFiles));
-                extraInfo = "AMTA tags more and bwav files.";
+                extraInfo = "AMTA tags more than bwav files.";
             }
 
         }

--- a/BARS/BARS.cs
+++ b/BARS/BARS.cs
@@ -13,6 +13,8 @@ namespace BARS
         public BARSHeader Header;
         public AMTA[] AMTA;
         public BWAV[] BWAV;
+        private string duplicatedFiles = "These files are the linked to the same content:\n\n";
+        private Dictionary<uint, List<string>> bwavFileNames = new Dictionary<uint, List<string>>();
 
         public BARSAudio(FileReader reader)
         {
@@ -24,12 +26,43 @@ namespace BARS
             {
                 try
                 {
-                    AMTA[index] = new AMTA(reader, Header.Offsets[index], Header.SizeCache[Header.Offsets[index]]);
-                        
+                    reader.Seek(Header.AMTAStartAddr[index], SeekOrigin.Begin);
+                    AMTA[index] = new AMTA(reader, Header.Offsets[index], Header.SizeCache[Header.Offsets[index]]);   
                 }
                 catch(Exception)
                 {
                     Console.WriteLine(reader.BaseStream.Position);
+                }
+            }
+
+            foreach (var AMTAEntry in AMTA)
+            {
+                if (!bwavFileNames.ContainsKey(AMTAEntry.DataOffset)) { bwavFileNames[AMTAEntry.DataOffset] = new List<string>(); };
+                bwavFileNames[AMTAEntry.DataOffset].Add(AMTAEntry.Label);
+            }
+
+            int idx = 0;
+            foreach (var elem in bwavFileNames)
+            {
+                var nameList = elem.Value;
+                if (nameList.Count > 1)
+                {
+                    var fileNames = "";
+                    foreach (var name in nameList)
+                    {
+                        fileNames += name;
+                        fileNames += "\n";
+                    }
+
+                    duplicatedFiles += "================";
+                    duplicatedFiles += idx;
+                    duplicatedFiles += "================\n";
+                    duplicatedFiles += fileNames;
+                    duplicatedFiles += "================";
+                    duplicatedFiles += "end";
+                    duplicatedFiles += "================\n\n";
+
+                    idx += 1;
                 }
             }
 
@@ -50,11 +83,14 @@ namespace BARS
 
         public void Export(string path, bool fileAsSubPath = false)
         {
+            var savePath = fileAsSubPath ? $"{path}\\{Name}\\" : $"{path}\\";
             foreach (var bwav in BWAV)
-            {
-                var savePath = fileAsSubPath ? $"{path}\\{Name}\\" : $"{path}\\";
+            {               
                 File.WriteAllBytes($@"{savePath}{bwav.Name}.bwav", bwav.Data);
             }
+
+            var infoPath = $@"{savePath}\\duplicated_files.txt";
+            File.WriteAllBytes(infoPath, Encoding.UTF8.GetBytes(duplicatedFiles));
         }
 
         public IEnumerable<string> List => BWAV.Select(b => b.Name);
@@ -112,8 +148,10 @@ namespace BARS
         public uint[] Hashes;
         public Dictionary<uint, uint> SizeCache = new Dictionary<uint, uint>();
         public List<uint> Offsets;
+        public int uniqueFileCount;
+        public uint AMTAStart = 0;
 
-        public uint AMTAStart { get; set; }
+        public List<uint> AMTAStartAddr;
         public uint BWAVStart => Offsets[0];
 
         public BARSHeader(FileReader reader)
@@ -134,11 +172,16 @@ namespace BARS
             Hashes = reader.ReadMultipleUInt32(Count);
 
             Offsets = new List<uint>();
+            AMTAStartAddr = new List<uint>();
 
             for (var index = 0; index < Count; ++index)
             {
-                var dataStart = reader.ReadUInt32();
-                if (AMTAStart == 0) AMTAStart = dataStart;
+                var data = reader.ReadUInt32();
+                if (AMTAStart == 0)
+                {
+                    AMTAStart = data;
+                }
+                AMTAStartAddr.Add(data);
 
                 var offset = reader.ReadUInt32();
                 if (offset == 0 || offset == uint.MaxValue)
@@ -150,6 +193,7 @@ namespace BARS
             }
 
             var uniqueOffsets = Offsets.Distinct().OrderBy(a => a).ToArray();
+            uniqueFileCount = uniqueOffsets.Length;
 
             for (var index = 0; index < uniqueOffsets.Length - 1; ++index)
             {

--- a/BarsExtract/Program.cs
+++ b/BarsExtract/Program.cs
@@ -6,29 +6,44 @@ namespace BarsExtract
 {
     public class Program
     {
+        private static void DumpABarFile(string filePath)
+        {
+            var name = Path.GetFileNameWithoutExtension(filePath);
+            var dir = Path.GetDirectoryName(filePath);
+            Directory.CreateDirectory($@"{dir}\{name}");
+            var fileIn = BARSAudio.Read(filePath);
+            string info;
+            fileIn.Export(dir, true, out info);
+            if (info != "")
+            {
+                Console.WriteLine(filePath + ": " + info);
+            }
+        }
+
         public static void Main(string[] args)
         {
-            var filename = args[0];
-            if (!File.Exists(filename))
+            try
             {
-                Console.WriteLine("File does not exist.");
-                return;
+                var filePath = args[0];
+                filePath = Path.GetFullPath(filePath);
+                FileAttributes attr = File.GetAttributes(filePath);
+                if (attr.HasFlag(FileAttributes.Directory))
+                {
+                    var files = Directory.GetFiles(filePath);
+                    foreach (var file in files)
+                    {
+                        DumpABarFile(file);
+                    }
+                }
+                else
+                {
+                    DumpABarFile(filePath);
+                }
             }
-            filename = Path.GetFullPath(filename);
-
-            var name = Path.GetFileNameWithoutExtension(filename);
-            var dir = Path.GetDirectoryName(filename);
-
-            Directory.CreateDirectory($@"{dir}\{name}");
-
-            var fileIn = BARSAudio.Read(filename);
-
-            foreach (var itemName in fileIn.List)
+            catch (Exception e)
             {
-                Console.WriteLine($"{itemName}");
+                Console.WriteLine(e);
             }
-
-            fileIn.Export(dir, true);
         }
     }
 }

--- a/BarsExtract/Program.cs
+++ b/BarsExtract/Program.cs
@@ -8,15 +8,14 @@ namespace BarsExtract
     {
         public static void Main(string[] args)
         {
-            // This is just a basic implementation of the class to extract files. 
-
             var filename = args[0];
-
             if (!File.Exists(filename))
             {
                 Console.WriteLine("File does not exist.");
                 return;
             }
+            filename = Path.GetFullPath(filename);
+
             var name = Path.GetFileNameWithoutExtension(filename);
             var dir = Path.GetDirectoryName(filename);
 

--- a/BarsExtract/Properties/launchSettings.json
+++ b/BarsExtract/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "BarsExtract": {
+      "commandName": "Project",
+      "commandLineArgs": "test.bars"
+    }
+  }
+}


### PR DESCRIPTION
Hi, i found your project interesting and capable of handling the scenario where the number of AMTA tags are greater than bwav content. 
In this comment, I add a feature which can provide a list showing multiple AMTA tags point to the same bwav file, which is some case can be illuminating. Also, i change the code which makes connection of the bwav and its file name, i think it is a more strict way of parsing  the bar file.

regards.